### PR TITLE
2.0.4 Add support for older numpy and imageio versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ pip install frechet-coefficient[torch] # for PyTorch support
 ```
 
 Requirements:
-- Python 3.10-3.12
-- TensorFlow 2.18.* OR PyTorch 2.5.*
-- imageio 2.36.*
-- numpy >= 2.0.0
+- Python 3.9-3.12
+- TensorFlow 2.18.* OR PyTorch 2.5.* # you can try older versions too
+- imageio 2.29.*
+- numpy >= 1.21.*
 
 
 ## Usage
@@ -141,7 +141,8 @@ hd = ism.calculate_hellinger_distance(images_1_patches, images_2_patches, batch_
 - `fc`: Frechet Coefficient
 - `hd`: Hellinger Distance
 
-The Hellinger Distance is numerically unstable for small datasets. The main reason is poorly estimated covariance matrices. To mitigate this issue, you can use the `--random_patches` argument to calculate metrics on random patches of images with a very high number of patches (e.g., 50000).
+The Hellinger Distance is numerically unstable for small datasets. The main reason is poorly estimated covariance matrices and calculating determinant of a large matrix (e.g. 768x768) might lead to numerical instability.
+To mitigate this issue, you can use the `--random_patches` argument to calculate metrics on random patches of images with a very high number of patches (e.g., 50000).
 
 ### Models
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ path = "src/frechet_coefficient/__init__.py"
 name = "frechet-coefficient"
 dynamic = ["version"]
 dependencies = [
-    "imageio~=2.36.0",
-    "numpy>=2.0.0"
+    "imageio~=2.29.0",
+    "numpy>=1.21.0"
 ]
 requires-python = ">=3.9,<3.13"
 authors = [

--- a/src/frechet_coefficient/__init__.py
+++ b/src/frechet_coefficient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 try:
     import tensorflow

--- a/src/frechet_coefficient/metrics.py
+++ b/src/frechet_coefficient/metrics.py
@@ -151,7 +151,7 @@ def hellinger_distance(mean1: np.ndarray, cov1: np.ndarray, mean2: np.ndarray, c
     det2 = np.linalg.det(cov2)
     det3 = np.linalg.det(sum_of_sigma / 2)
 
-    term1 = (det1**0.25 * det2**0.25) / (det3**0.5)
+    term1 = (det1**0.25 * det2**0.25) / (det3**0.5 + 1e-7)
     term2 = (mean1 - mean2) @ np.linalg.pinv(sum_of_sigma / 2) @ (mean1 - mean2) / 0.125
 
     return 1 - np.real(term1) * np.real(np.exp(-term2))

--- a/tests/imports_tf_torch.py
+++ b/tests/imports_tf_torch.py
@@ -11,3 +11,9 @@ class TestImports(unittest.TestCase):
         # This test will fail if torch is imported
         with self.assertRaises(ModuleNotFoundError):
             import torch
+
+    def test_import_imageio(self):
+        try:
+            import imageio.v3
+        except ModuleNotFoundError:
+            self.fail("imageio not imported")


### PR DESCRIPTION
### Dependency Updates:
* Updated the `imageio` dependency from version `2.36.0` to `2.29.0` and the `numpy` dependency to a minimum version of `1.21.0` in `pyproject.toml`.
* Updated the Python version requirement to include Python 3.9 in `README.md`.

### Documentation Improvements:
* Added a note about the numerical instability of the Hellinger Distance for small datasets and the impact of large matrix determinants in `README.md`.

### Code Improvements:
* Improved the numerical stability of the Hellinger Distance calculation by adding a small constant to the denominator in `metrics.py`.

### Version Update:
* Incremented the package version from `2.0.3` to `2.0.4` in `__init__.py`.

### New Tests:
* Added a test to ensure `imageio.v3` is imported correctly in `imports_tf_torch.py`.