### PR TITLE
2.0.6 - CLI hotfix for Python 3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-tensorflow[and-cuda]~=2.18.0
-imageio~=2.36.0
-numpy>=2.0.0

--- a/src/frechet_coefficient/__init__.py
+++ b/src/frechet_coefficient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.5"
+__version__ = "2.0.6"
 
 try:
     import tensorflow

--- a/src/frechet_coefficient/cli.py
+++ b/src/frechet_coefficient/cli.py
@@ -63,15 +63,14 @@ def main() -> None:
         images1 = crop_random_patches(images1, (args.patch_size, args.patch_size), args.num_of_patch)
         images2 = crop_random_patches(images2, (args.patch_size, args.patch_size), args.num_of_patch)
 
-    match args.metric:
-        case "fd":
-            metric = ism.calculate_frechet_distance(images1, images2, args.batch_size)
-        case "fc":
-            metric = ism.calculate_frechet_coefficient(images1, images2, args.batch_size)
-        case "hd":
-            metric = ism.calculate_hellinger_distance(images1, images2, args.batch_size)
-        case _:
-            raise ValueError(f"Invalid metric {args.metric}")
+    if args.metric == "fd":
+        metric = ism.calculate_frechet_distance(images1, images2, args.batch_size)
+    elif args.metric == "fc":
+        metric = ism.calculate_frechet_coefficient(images1, images2, args.batch_size)
+    elif args.metric == "hd":
+        metric = ism.calculate_hellinger_distance(images1, images2, args.batch_size)
+    else:
+        raise ValueError(f"Invalid metric {args.metric}")
 
     print(f"Calculated {args.metric}: {metric}")
 


### PR DESCRIPTION
Version update:
* [`src/frechet_coefficient/__init__.py`](diffhunk://#diff-181143fcaeddd58c33637eb4fe0c320833270aa7a311dda696204e07a8e541c5L1-R1): Updated the version from `2.0.5` to `2.0.6`.

Refactor of metric selection:
* [`src/frechet_coefficient/cli.py`](diffhunk://#diff-732879aeb0b8c8463823e0e1132a75b92fa90386dda9bc35e9912d33123ee7b7L66-R72): Refactored the `main` function to replace the `match` statement with `if-elif-else` statements for selecting the metric.